### PR TITLE
Fix typos

### DIFF
--- a/pages/ngs/signup.js
+++ b/pages/ngs/signup.js
@@ -154,7 +154,7 @@ export default class Pricing extends React.Component {
 	  <code>
             // Go client
             <br />
-            nc, err := nats.Connect(url, nats.UserCreds("~/.nkeys/synadia/accounts/ngs/users/ngs.creds"))
+            nc, err := nats.Connect(url, nats.UserCredentials("~/.nkeys/synadia/accounts/ngs/users/ngs.creds"))
             <br />
             <br />
             // Node.js client

--- a/pages/ngs/signup.js
+++ b/pages/ngs/signup.js
@@ -146,15 +146,15 @@ export default class Pricing extends React.Component {
 	    When you are ready to program your own NGS client, you can
 	    get started with one of our NGS aware clients. We have
 	    support
-	    for <a href="https://github.com/nats-io/go-nats#new-authentication-nkeys-and-user-credentials"><span className="highlight">Go </span></a>
-	    and <a href="https://github.com/nats-io/node-nats#new-authentication-nkeys-and-user-credentials"><span className="highlight">Node.js </span></a>
+	    for <a href="https://github.com/nats-io/nats.go#new-authentication-nkeys-and-user-credentials"><span className="highlight">Go </span></a>
+	    and <a href="https://github.com/nats-io/nats.js#new-authentication-nkeys-and-user-credentials"><span className="highlight">Node.js </span></a>
 	    for launch, with more clients to be released soon.
 	  </p>
 
 	  <code>
             // Go client
             <br />
-            nc, err := Connect(url, UserCreds(“~/.nkeys/synadia/accounts/ngs/users/ngs.creds”)
+            nc, err := nats.Connect(url, nats.UserCreds("~/.nkeys/synadia/accounts/ngs/users/ngs.creds"))
             <br />
             <br />
             // Node.js client


### PR DESCRIPTION
Currently, the Go and Node.js links are old URLs. For the Node.js link, this is okay because it seems like the repo was renamed and GitHub automatically redirects to the new path. However, for the Go link, the original repo was archived and a new one was created, so GitHub does not redirect to the new path.

In addition, the Go code sample was missing an ending parenthesis, using smart instead of dumb quotes, and was missing the package name. This makes it so users can't just copy paste the text.

This change updates the URLs and fixes the syntax errors.